### PR TITLE
Stack with S3 bucket, sqs notifications, IAM roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
 lib64/
 parts/
 sdist/

--- a/node/s3-sqs/.gitignore
+++ b/node/s3-sqs/.gitignore
@@ -1,0 +1,9 @@
+node_modules
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out
+
+# Parcel build directories
+.cache
+.build

--- a/node/s3-sqs/.npmignore
+++ b/node/s3-sqs/.npmignore
@@ -1,0 +1,3 @@
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/node/s3-sqs/README.md
+++ b/node/s3-sqs/README.md
@@ -1,0 +1,20 @@
+# Example of CDK in Javascript
+
+This is project deploys s3 bucket with sqs notifications using basic CDK constructs.
+
+## Development
+
+`cd node/s3-sqs`
+`npm install`
+`cdk deploy`
+
+## Useful commands
+ * `cdk metadata S3SqsStack` list resources
+ * `npm run test`         perform the jest unit tests
+ * `cdk deploy`           deploy this stack to your default AWS account/region
+ * `cdk diff`             compare deployed stack with current state
+ * `cdk synth`            emits the synthesized CloudFormation template
+
+## TODO
+
+Fix tests...

--- a/node/s3-sqs/README.md
+++ b/node/s3-sqs/README.md
@@ -6,7 +6,13 @@ This is project deploys s3 bucket with sqs notifications using basic CDK constru
 
 `cd node/s3-sqs`
 `npm install`
-`cdk deploy`
+
+```
+cdk deploy "S3Sqs*" \
+	--parameters S3SqsStackDev:environment=dev \
+	--parameters S3SqsStackTest:environment=test \
+	--parameters extAccount=111234567899 
+```
 
 ## Useful commands
  * `cdk metadata S3SqsStack` list resources

--- a/node/s3-sqs/bin/s3-sqs.js
+++ b/node/s3-sqs/bin/s3-sqs.js
@@ -4,7 +4,14 @@ const cdk = require('@aws-cdk/core');
 const { S3SqsStack } = require('../lib/s3-sqs-stack');
 
 const app = new cdk.App();
-new S3SqsStack(app, 'S3SqsStack', {
+
+new S3SqsStack(app, 'S3SqsStackDev', {
+    env : {
+        region : 'us-east-1'
+    }
+});
+
+new S3SqsStack(app, 'S3SqsStackTest', {
     env : {
         region : 'us-east-1'
     }

--- a/node/s3-sqs/bin/s3-sqs.js
+++ b/node/s3-sqs/bin/s3-sqs.js
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+const cdk = require('@aws-cdk/core');
+const { S3SqsStack } = require('../lib/s3-sqs-stack');
+
+const app = new cdk.App();
+new S3SqsStack(app, 'S3SqsStack', {
+    env : {
+        region : 'us-east-1'
+    }
+});

--- a/node/s3-sqs/cdk.json
+++ b/node/s3-sqs/cdk.json
@@ -1,0 +1,7 @@
+{
+  "app": "node bin/s3-sqs.js",
+  "context": {
+    "@aws-cdk/core:enableStackNameDuplicates": "true",
+    "aws-cdk:enableDiffNoFail": "true"
+  }
+}

--- a/node/s3-sqs/lib/s3-sqs-stack.js
+++ b/node/s3-sqs/lib/s3-sqs-stack.js
@@ -1,0 +1,62 @@
+const cdk = require('@aws-cdk/core');
+const s3 = require('@aws-cdk/aws-s3');
+const sqs = require('@aws-cdk/aws-sqs')
+const s3_notify = require('@aws-cdk/aws-s3-notifications');
+const iam = require('@aws-cdk/aws-iam');
+class S3SqsStack extends cdk.Stack {
+  /**
+   *
+   * @param {cdk.Construct} scope
+   * @param {string} id
+   * @param {cdk.StackProps=} props
+   */
+  constructor(scope, id, props) {
+    super(scope, id, props);
+
+    const stack = cdk.Stack.of(this);
+    
+    const extAccount = new cdk.CfnParameter(this, "extAccount", {
+      type: "String",
+      description: "AWS account id that can assume CrossAccountRole role"});    
+
+    const env = new cdk.CfnParameter(this, "environment", {
+      type: "String",
+      description: "Environment name"});    
+       
+    const bucket = new s3.Bucket(this, "myBucket", {
+        bucketName: 'ets'+'-'+stack.account+'-'+env.valueAsString+'-'+'s3-bucket',
+        removalPolicy : cdk.RemovalPolicy.DESTROY});
+    
+    const my_queue = new sqs.Queue(this, 'mySqs', {
+      queueName: 'ets'+'-'+stack.account+'-'+env.valueAsString+'-'+'testQueue',
+      visibilityTimeout: cdk.Duration.seconds(300),
+      retentionPeriod: cdk.Duration.seconds(1209600)
+    });
+
+    bucket.addEventNotification(s3.EventType.OBJECT_CREATED,
+      new s3_notify.SqsDestination(my_queue));
+    
+    // role and policy for Lambda to read from above bucket
+    const role = new iam.Role(this, 'myRole', {
+      assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+    });
+
+    role.addToPolicy(new iam.PolicyStatement({
+      resources: [ bucket.bucketArn, bucket.bucketArn+'/*' ],
+      actions: ['s3:Get*', 's3:List'] }));
+
+    // IAM role Allow access from other accounts
+    // for multiple accounts - use conditions with aws:PrincipalOrgPaths
+    // https://aws.amazon.com/blogs/security/iam-share-aws-resources-groups-aws-accounts-aws-organizations/ 
+    const cross_acct_role = new iam.Role(this, 'CrossAccountRole', {
+      assumedBy: new iam.AccountPrincipal(extAccount.valueAsString),
+    });
+
+    cross_acct_role.addToPolicy(new iam.PolicyStatement({
+      resources: [ bucket.bucketArn, bucket.bucketArn+'/*' ],
+      actions: ['s3:Get*', 's3:List'] }));
+
+    }
+}
+
+module.exports = { S3SqsStack }

--- a/node/s3-sqs/manual_cf.yaml
+++ b/node/s3-sqs/manual_cf.yaml
@@ -17,3 +17,14 @@ Resources:
     Metadata:
       resource: Mystack/myBucket/Resource
       comment: Shared S3 bucket for the environment
+
+  mySqs:
+    Type: AWS::SQS::Queue
+    Properties:
+      MessageRetentionPeriod: 1209600
+      QueueName:
+        !Sub 'ets-${AWS::AccountId}-${environment}-queue'
+      VisibilityTimeout: 300
+    Metadata:
+      resource: Mystack/mySqs/Resource
+      comment: sqs where bucket should send notifications

--- a/node/s3-sqs/manual_cf.yaml
+++ b/node/s3-sqs/manual_cf.yaml
@@ -1,0 +1,19 @@
+Parameters:
+  extAccount:
+    Type: String
+    Description: AWS account id that can assume CrossAccountRole role
+  environment:
+    Type: String
+    Description: Environment name
+
+Resources:
+  myBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName:
+        !Sub 'ets-${AWS::AccountId}-${environment}-s3-bucket'
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+    Metadata:
+      resource: Mystack/myBucket/Resource
+      comment: Shared S3 bucket for the environment

--- a/node/s3-sqs/manual_cf.yaml
+++ b/node/s3-sqs/manual_cf.yaml
@@ -9,9 +9,14 @@ Parameters:
 Resources:
   myBucket:
     Type: AWS::S3::Bucket
+    DependsOn: [ "SQSPolicy", "mySqs"]
     Properties:
       BucketName:
         !Sub 'ets-${AWS::AccountId}-${environment}-s3-bucket'
+      NotificationConfiguration:
+        QueueConfigurations:
+          - Event: s3:ObjectCreated:*
+            Queue: !GetAtt mySqs.Arn
     UpdateReplacePolicy: Delete
     DeletionPolicy: Delete
     Metadata:
@@ -28,3 +33,21 @@ Resources:
     Metadata:
       resource: Mystack/mySqs/Resource
       comment: sqs where bucket should send notifications
+  
+  SQSPolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal: "*"
+            Action: SQS:SendMessage
+            Resource: !GetAtt mySqs.Arn
+            # Workaround for CF circular dependency (queue -> bucket -> queue)
+            Condition:
+              ArnEquals:
+                aws:SourceArn:
+                  !Sub 'arn:aws:s3:*:*:ets-${AWS::AccountId}-${environment}-s3-bucket'
+      Queues:
+        - !Ref mySqs

--- a/node/s3-sqs/package.json
+++ b/node/s3-sqs/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "s3-sqs",
+  "version": "0.1.0",
+  "bin": {
+    "s3-sqs": "bin/s3-sqs.js"
+  },
+  "scripts": {
+    "build": "echo \"The build step is not required when using JavaScript!\" && exit 0",
+    "cdk": "cdk",
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@aws-cdk/assert": "1.47.0",
+    "aws-cdk": "1.47.0",
+    "jest": "^25.5.0"
+  },
+  "dependencies": {
+    "@aws-cdk/aws-lambda": "^1.54.0",
+    "@aws-cdk/aws-s3": "^1.54.0",
+    "@aws-cdk/aws-s3-notifications": "^1.54.0",
+    "@aws-cdk/aws-sqs": "^1.54.0",
+    "@aws-cdk/core": "1.47.0"
+  }
+}

--- a/node/s3-sqs/params-dev.json
+++ b/node/s3-sqs/params-dev.json
@@ -1,0 +1,10 @@
+[
+  {
+    "ParameterKey": "extAccount",
+    "ParameterValue": "208334959160"
+  }, 
+  {
+    "ParameterKey": "environment",
+    "ParameterValue": "dev1"
+  }
+]

--- a/node/s3-sqs/test/s3-sqs.test.js
+++ b/node/s3-sqs/test/s3-sqs.test.js
@@ -1,0 +1,13 @@
+const { expect, matchTemplate, MatchStyle } = require('@aws-cdk/assert');
+const cdk = require('@aws-cdk/core');
+const S3Sqs = require('../lib/s3-sqs-stack');
+
+test('Empty Stack', () => {
+    const app = new cdk.App();
+    // WHEN
+    const stack = new S3Sqs.S3SqsStack(app, 'MyTestStack');
+    // THEN
+    expect(stack).to(matchTemplate({
+      "Resources": {}
+    }, MatchStyle.EXACT))
+});


### PR DESCRIPTION
This is an example of creating linked resources with CDK using javascript.

- s3 and sqs resource names are parametrized
- aws-cdk/aws-s3-notifications construct is used to configure s3->sqs notifications
- `assumedBy` is used to grant assume role permissions to an external account  (I've used the same account since CF validates account numbers)
